### PR TITLE
Added more specific error message

### DIFF
--- a/pk2cmd/cmd_app.cpp
+++ b/pk2cmd/cmd_app.cpp
@@ -351,7 +351,7 @@ void Ccmd_app::processArgs(int argc, _TCHAR* argv[])
 	// look for the device in the device file - still need to do this on autodetect to properly set up buffers.
 	if(!PicFuncs.FindDevice(tempString))
 	{
-		printf("Could not find device %s.\n\n", tempString);
+		printf("The %s device is not supported: it's definition could not be found in the device defintions file.\n\n", tempString);
 		fflush(stdout);
 		ReturnCode = INVALID_CMDLINE_ARG;
 		return;

--- a/pk2cmd/cmd_app.cpp
+++ b/pk2cmd/cmd_app.cpp
@@ -351,7 +351,7 @@ void Ccmd_app::processArgs(int argc, _TCHAR* argv[])
 	// look for the device in the device file - still need to do this on autodetect to properly set up buffers.
 	if(!PicFuncs.FindDevice(tempString))
 	{
-		printf("The %s device is not supported: it's definition could not be found in the device defintions file.\n\n", tempString);
+		printf("The %s device is not supported: it's definition could not be found in the device definitions file.\n\n", tempString);
 		fflush(stdout);
 		ReturnCode = INVALID_CMDLINE_ARG;
 		return;


### PR DESCRIPTION
Fixes #4 
The program will say the following for the non supported parts:

> The PIC16F1718 device is not supported: it's definition could not be found in the device definitions file.

Instead of:

> Could not find device PIC16F1718