### PR TITLE
Reset usb device

### DIFF
--- a/pk2cmd/pk2usb.cpp
+++ b/pk2cmd/pk2usb.cpp
@@ -337,6 +337,9 @@ pickit_dev *usbPickitOpen(int unitIndex, char *unitID)
 							return NULL;
 						}
 	#endif
+						/* Need a reset here */
+						usb_reset(d);
+
 						cmd[0] = GETVERSION;
 						sendPickitCmd(d, cmd, 1);
 						recvUSB(d, 8, retData);


### PR DESCRIPTION
without the reset the PICkit 2 works with pk2cmd only directly after you plug it in. Every further call to pk2cmd fails.